### PR TITLE
Fixed typo for tags.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,13 +56,13 @@
 
   - include: apt.yml
     when: ansible_pkg_mgr == 'apt'
-    tag:
+    tags:
       - apt
       - package
 
   - include: rpm.yml
     when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
-    tag:
+    tags:
       - package
       - rpm
 


### PR DESCRIPTION
The apt.yml and rpm.yml includes in main.yml had an incorrect 'tag' attribute which should have been 'tags'. This was also causing a deprecation warning in ansible 2.1.0.0.
